### PR TITLE
getEnvのところをデフォルトを変更

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ func getYaml() map[interface{}]interface{} {
 func getGoEnv() string {
 	_goEnv := os.Getenv("GO_ENV")
 	if _goEnv == "" {
-		return "develop"
+		return "development"
 	}
 	return _goEnv
 }


### PR DESCRIPTION
defaultをdevelopからdevelopmentに変更

`dbconfig.yml` のデフォルトが `development ` であるためそこに合わせないと例えばsql-migrateなんかのツールを使ったときにパースでエラーが起きる